### PR TITLE
[Refactor] pdf 관련 상태 zustand로 관리

### DIFF
--- a/src/components/MyDocumentAll.tsx
+++ b/src/components/MyDocumentAll.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 import {
   Document,
   Page,
@@ -6,83 +6,77 @@ import {
   View,
   StyleSheet,
   Font,
-} from '@react-pdf/renderer';
+} from "@react-pdf/renderer";
+import { ItemState } from "../types/document";
 
 Font.register({
-  family: 'MalgunGothic',
+  family: "MalgunGothic",
   fonts: [
     {
       src: `${import.meta.env.BASE_URL}fonts/malgun.ttf`,
-      fontWeight: 'normal',
+      fontWeight: "normal",
     },
     {
       src: `${import.meta.env.BASE_URL}fonts/malgunbd.ttf`,
-      fontWeight: 'bold',
+      fontWeight: "bold",
     },
   ],
 });
 
 const styles = StyleSheet.create({
-  page: { padding: 30, fontFamily: 'MalgunGothic' },
+  page: { padding: 30, fontFamily: "MalgunGothic" },
 
   /* === 타이틀 영역 === */
   titleWrap: { marginBottom: 16 },
   titleEyebrow: {
     fontSize: 10,
-    color: '#6B7280',
+    color: "#6B7280",
     marginBottom: 4,
     letterSpacing: 0.5,
   },
-  titleRow: { flexDirection: 'row', alignItems: 'center' },
+  titleRow: { flexDirection: "row", alignItems: "center" },
   titleAccent: {
     width: 4,
     height: 24,
-    backgroundColor: '#2563EB',
+    backgroundColor: "#2563EB",
     marginRight: 8,
   },
-  titleText: { fontSize: 22, fontWeight: 'bold', color: '#111827' },
-  titleRule: { marginTop: 6, height: 2, backgroundColor: '#2563EB' },
+  titleText: { fontSize: 22, fontWeight: "bold", color: "#111827" },
+  titleRule: { marginTop: 6, height: 2, backgroundColor: "#2563EB" },
 
-  /* === 문항(Question) 영역: 라벨 제거 === */
+  /* === 문항(Question) 영역 === */
   questionWrap: { marginBottom: 16 },
   questionBox: {
-    backgroundColor: '#F3F4F6', // gray-100
+    backgroundColor: "#F3F4F6",
     borderRadius: 4,
     borderWidth: 1,
-    borderColor: '#E5E7EB', // gray-200
+    borderColor: "#E5E7EB",
     paddingVertical: 6,
     paddingHorizontal: 10,
   },
-  questionBoxRow: { flexDirection: 'row', alignItems: 'center' },
+  questionBoxRow: { flexDirection: "row", alignItems: "center" },
   questionBar: {
     width: 3,
     height: 18,
-    backgroundColor: '#2563EB',
+    backgroundColor: "#2563EB",
     borderRadius: 2,
     marginRight: 8,
   },
-  questionText: { fontSize: 14, color: '#111827' },
+  questionText: { fontSize: 14, color: "#111827" },
 
   /* 본문 섹션 */
   section: { marginBottom: 15 },
   sectionTitle: {
     fontSize: 16,
-    fontWeight: 'bold',
-    color: '#111827',
+    fontWeight: "bold",
+    color: "#111827",
     marginBottom: 8,
   },
   text: { fontSize: 14, marginBottom: 5 },
-  label: { fontWeight: 'bold' },
+  label: { fontWeight: "bold" },
 });
 
-export type Snap = {
-  title: string;
-  userAnswer: string;
-  aiAnswer: string;
-  qa: { question: string; answer: string }[];
-};
-
-const MyDocumentAll: React.FC<{ items: Snap[] }> = ({ items }) => (
+const MyDocumentAll: React.FC<{ items: ItemState[] }> = ({ items }) => (
   <Document>
     {items.map((it, i) => (
       <Page key={i} size="A4" style={styles.page} wrap>
@@ -101,7 +95,7 @@ const MyDocumentAll: React.FC<{ items: Snap[] }> = ({ items }) => (
           <View style={styles.questionBox}>
             <View style={styles.questionBoxRow}>
               <View style={styles.questionBar} />
-              <Text style={styles.questionText}>{it.title || '제목 없음'}</Text>
+              <Text style={styles.questionText}>{it.title || "제목 없음"}</Text>
             </View>
           </View>
         </View>
@@ -110,10 +104,10 @@ const MyDocumentAll: React.FC<{ items: Snap[] }> = ({ items }) => (
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>사용자 답변</Text>
           <Text style={styles.text}>
-            {(it.userAnswer || '입력 없음').split('\n').map((line, idx) => (
+            {(it.userAnswer || "입력 없음").split("\n").map((line, idx) => (
               <Text key={idx}>
                 {line}
-                {'\n'}
+                {"\n"}
               </Text>
             ))}
           </Text>
@@ -123,10 +117,10 @@ const MyDocumentAll: React.FC<{ items: Snap[] }> = ({ items }) => (
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>AI 첨삭 답변</Text>
           <Text style={styles.text}>
-            {(it.aiAnswer || '내용 없음').split('\n').map((line, idx) => (
+            {(it.aiAnswer || "내용 없음").split("\n").map((line, idx) => (
               <Text key={idx}>
                 {line}
-                {'\n'}
+                {"\n"}
               </Text>
             ))}
           </Text>

--- a/src/pages/documentPage/DocumentPage.tsx
+++ b/src/pages/documentPage/DocumentPage.tsx
@@ -4,16 +4,16 @@ import React, {
   useState,
   useMemo,
   useCallback,
-} from 'react';
-import s from '../styles/DocumentPage.module.scss';
-import DocumentItem from './components/DocumentItem';
-import type { ItemHandle } from '../../types/document';
-import { revisingTitles } from '../../data/revisingTitleData';
-import RightOrbit from '../../components/RightOrbit';
-import { BASE_LABELS, BASE_POSITION } from '../../data/documentData';
-import { pdf } from '@react-pdf/renderer';
-import MyDocumentAll from '../../components/MyDocumentAll';
-import WarningModal from '../../components/WarningModal';
+} from "react";
+import s from "../styles/DocumentPage.module.scss";
+import DocumentItem from "./components/DocumentItem";
+import { revisingTitles } from "../../data/revisingTitleData";
+import RightOrbit from "../../components/RightOrbit";
+import { BASE_LABELS, BASE_POSITION } from "../../data/documentData";
+import { pdf } from "@react-pdf/renderer";
+import MyDocumentAll from "../../components/MyDocumentAll";
+import WarningModal from "../../components/WarningModal";
+import { useDocStore } from "../../store/documentStore";
 
 function rotateToCenter5<T>(
   arr: readonly [T, T, T, T, T],
@@ -41,21 +41,9 @@ const DocumentPage = () => {
 
   const sectionRefs = useRef<(HTMLDivElement | null)[]>([]);
 
-  const itemHandlesRef = useRef<(ItemHandle | null)[]>([]);
-
-  if (itemHandlesRef.current.length !== revisingTitles.length) {
-    itemHandlesRef.current = Array(revisingTitles.length).fill(null);
-  }
   if (sectionRefs.current.length !== revisingTitles.length) {
     sectionRefs.current = Array(revisingTitles.length).fill(null);
   }
-
-  const setItemHandle = useCallback(
-    (idx: number) => (inst: ItemHandle | null) => {
-      itemHandlesRef.current[idx] = inst;
-    },
-    []
-  );
 
   const labelsForOrbit = useMemo(
     () => rotateToCenter5(BASE_LABELS, activeSection),
@@ -95,32 +83,22 @@ const DocumentPage = () => {
     if (downloading) return;
     setDownloading(true);
     try {
-      const items = itemHandlesRef.current.map((handle, idx) => {
-        const snap = handle?.getSnapshot?.();
-        return (
-          snap ?? {
-            title: revisingTitles[idx].title,
-            userAnswer: '',
-            aiAnswer: '',
-            qa: [],
-          }
-        );
-      });
-
+      const items = useDocStore.getState().getAll();
       const instance = pdf(<MyDocumentAll items={items} />);
+
       const blob = await instance.toBlob();
       const url = URL.createObjectURL(blob);
 
-      const a = document.createElement('a');
+      const a = document.createElement("a");
       a.href = url;
-      a.download = '전체_지원서류.pdf';
+      a.download = "전체_지원서류.pdf";
       document.body.appendChild(a);
       a.click();
       a.remove();
       URL.revokeObjectURL(url);
     } catch (e) {
-      console.error('PDF 생성 오류:', e);
-      alert('PDF 생성 중 오류가 발생했습니다.');
+      console.error("PDF 생성 오류:", e);
+      alert("PDF 생성 중 오류가 발생했습니다.");
     } finally {
       setDownloading(false);
     }
@@ -128,7 +106,7 @@ const DocumentPage = () => {
 
   return (
     <div className={s.documentPageWrapper}>
-      <div className={s.orbitWrap} style={{ width: '12.45vw' }}>
+      <div className={s.orbitWrap} style={{ width: "12.45vw" }}>
         <RightOrbit
           side="left"
           labels={labelsForOrbit}
@@ -148,7 +126,6 @@ const DocumentPage = () => {
             ref={setSectionRef(index)}
           >
             <DocumentItem
-              ref={setItemHandle(index)}
               title={item.title}
               explanation={item.explanation}
               onExportAll={handleExportAll}

--- a/src/pages/documentPage/components/DocumentItem.tsx
+++ b/src/pages/documentPage/components/DocumentItem.tsx
@@ -1,63 +1,48 @@
-import React, { useRef, forwardRef, useImperativeHandle } from "react";
+import React, { useEffect } from "react";
 import s from "./Document.module.scss";
 import IconButton from "../../../components/IconButton";
 import PDF from "../../../assets/images/icon/download-icon.svg";
 import RevisingBox from "./RevisingBox";
 import QuestionsBox from "./QuestionsBox";
-import type {
-  ItemHandle,
-  DocumentItemProps,
-  RevisingBoxHandle,
-  QuestionsBoxHandle,
-} from "../../../types/document";
+import type { DocumentItemProps } from "../../../types/document";
+import { useDocStore } from "../../../store/documentStore";
 
 type Props = DocumentItemProps & {
   onRequireWarn?: () => void;
   questionNumber: number;
 };
 
-const DocumentItem = forwardRef<ItemHandle, Props>(
-  ({ title, explanation, onExportAll, onRequireWarn, questionNumber }, ref) => {
-    const revisingRef = useRef<RevisingBoxHandle>(null);
-    const questionsRef = useRef<QuestionsBoxHandle>(null);
+const DocumentItem = ({
+  title,
+  explanation,
+  onExportAll,
+  onRequireWarn,
+  questionNumber,
+}: Props) => {
+  const initItem = useDocStore((s) => s.initItem);
 
-    useImperativeHandle(ref, () => ({
-      getSnapshot() {
-        return {
-          title,
-          userAnswer: revisingRef.current?.getUserAnswer?.() || "",
-          aiAnswer: revisingRef.current?.getAiAnswer?.() || "",
-          qa: questionsRef.current?.getVisibleQA?.() || [],
-        };
-      },
-    }));
+  useEffect(() => {
+    initItem(questionNumber, title);
+  }, [questionNumber, title, initItem]);
 
-    const handleClick = () => {
-      if (onExportAll) onExportAll();
-    };
-
-    return (
-      <div className={s.documentItemContainer}>
-        <div className={s.pdfButton}>
-          <IconButton imgSrc={PDF} text="PDF" onClick={handleClick} />
-        </div>
-        <RevisingBox
-          ref={revisingRef}
-          title={title}
-          explanation={explanation}
-          questionNumber={questionNumber}
-        />
-
-        <QuestionsBox
-          ref={questionsRef}
-          getAiAnswer={() => revisingRef.current?.getAiAnswer?.() ?? ""}
-          onRequireWarn={onRequireWarn}
-          questionNumber={questionNumber}
-        />
+  return (
+    <div className={s.documentItemContainer}>
+      <div className={s.pdfButton}>
+        <IconButton imgSrc={PDF} text="PDF" onClick={onExportAll} />
       </div>
-    );
-  }
-);
+      <RevisingBox
+        title={title}
+        explanation={explanation}
+        questionNumber={questionNumber}
+      />
+
+      <QuestionsBox
+        onRequireWarn={onRequireWarn}
+        questionNumber={questionNumber}
+      />
+    </div>
+  );
+};
 
 DocumentItem.displayName = "DocumentItem";
 

--- a/src/pages/documentPage/components/QuestionsBox.tsx
+++ b/src/pages/documentPage/components/QuestionsBox.tsx
@@ -1,111 +1,108 @@
-import React, { useState, forwardRef, useImperativeHandle } from 'react';
-import s from './Document.module.scss';
-import b from '../../../components/styles/Box.module.scss';
-import ReportOutBox from '../../../components/ReportOutBox';
-import ReportInBox from '../../../components/ReportInBox';
-import type {
-  QuestionsBoxHandle,
-  ExtraProps,
-  QAItem,
-} from '../../../types/document';
-import createAiQnaApi from '../../../api/document/createAiQnaApi';
-import { aiAnswerSession$ } from '../../../utils/sessionStorage';
-import LoadingSpinner from '../../../components/LoadingSpinner';
+import React, { useState } from "react";
+import s from "./Document.module.scss";
+import b from "../../../components/styles/Box.module.scss";
+import ReportOutBox from "../../../components/ReportOutBox";
+import ReportInBox from "../../../components/ReportInBox";
+import type { QuestionsBoxProps, QAItem } from "../../../types/document";
+import createAiQnaApi from "../../../api/document/createAiQnaApi";
+import { aiAnswerSession$ } from "../../../utils/sessionStorage";
+import LoadingSpinner from "../../../components/LoadingSpinner";
+import { useDocStore } from "../../../store/documentStore";
 
-const QuestionsBox = forwardRef<QuestionsBoxHandle, ExtraProps>(
-  ({ getAiAnswer, onRequireWarn, questionNumber }, ref) => {
-    const [started, setStarted] = useState(false);
-    const [loading, setLoading] = useState(false);
-    const [qaList, setQaList] = useState<QAItem[]>([]);
+const QuestionsBox: React.FC<QuestionsBoxProps> = ({
+  onRequireWarn,
+  questionNumber,
+}) => {
+  // 전역 상태에서 이 문항의 qa만 부분 구독
+  const qa = useDocStore((s) => s.items[questionNumber]?.qa ?? []);
+  const update = useDocStore((s) => s.updateItem);
 
-    useImperativeHandle(ref, () => ({
-      getVisibleQA: () =>
-        (started ? qaList.slice(0, 4) : []).map((q) => ({
-          question: q.question,
-          answer: q.answer,
-        })),
-    }));
+  const [started, setStarted] = useState(false);
+  const [loading, setLoading] = useState(false);
+  //const [qaList, setQaList] = useState<QAItem[]>([]);
 
-    const fetchQna = async () => {
-      const ai = (getAiAnswer?.() ?? '').trim();
-      const aId = aiAnswerSession$(questionNumber).read();
-      if (aId == null || Number.isNaN(aId)) {
-        onRequireWarn?.();
-        return;
-      }
+  const fetchQna = async () => {
+    // 전역 상태에서 최신 aiAnswer 조회
+    const ai = (
+      useDocStore.getState().items[questionNumber]?.aiAnswer ?? ""
+    ).trim();
+    const aId = aiAnswerSession$(questionNumber).read();
+    if (aId == null || Number.isNaN(aId)) {
+      onRequireWarn?.();
+      return;
+    }
 
-      if (!ai || !aId) {
-        onRequireWarn?.();
-      }
+    if (!ai || !aId) {
+      onRequireWarn?.();
+    }
 
-      setLoading(true);
-      try {
-        const items = await createAiQnaApi(aId);
-        if (!items || items.length === 0)
-          throw new Error('생성된 예상 질문이 없습니다.');
-        setQaList(items);
-        setStarted(true);
-      } catch (err) {
-        console.error(err);
-      } finally {
-        setLoading(false);
-      }
-    };
+    setLoading(true);
+    try {
+      const items: QAItem[] = await createAiQnaApi(aId);
+      if (!items || items.length === 0)
+        throw new Error("생성된 예상 질문이 없습니다.");
 
-    const handleStart = () => fetchQna();
-    const handleRetry = () => fetchQna();
+      update(questionNumber, { qa: items }); // 전역 상태에 저장
+      setStarted(true);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
 
-    return (
-      <div className={s.questionBox}>
-        <ReportOutBox width="12.97vw" height="5.63vw">
-          <p className={s.infoText1}>
-            {`AI 첨삭 이후, 답변에 따른\n예상 질문도 생성해 보세요!`}
-          </p>
-        </ReportOutBox>
+  const handleStart = () => fetchQna();
+  const handleRetry = () => fetchQna();
 
-        <ReportOutBox width="12.97vw" height="33.28vw" className={b.column}>
-          <p className={s.infoText2}>문항별 질의응답 예상 질문</p>
+  return (
+    <div className={s.questionBox}>
+      <ReportOutBox width="12.97vw" height="5.63vw">
+        <p className={s.infoText1}>
+          {`AI 첨삭 이후, 답변에 따른\n예상 질문도 생성해 보세요!`}
+        </p>
+      </ReportOutBox>
 
-          {started && (
-            <button
-              className={s.retryButton}
-              onClick={loading ? undefined : handleRetry}
-              disabled={loading}
+      <ReportOutBox width="12.97vw" height="33.28vw" className={b.column}>
+        <p className={s.infoText2}>문항별 질의응답 예상 질문</p>
+
+        {started && (
+          <button
+            className={s.retryButton}
+            onClick={loading ? undefined : handleRetry}
+            disabled={loading}
+          >
+            {loading ? "생성 중..." : "다른질문 보기"}
+          </button>
+        )}
+
+        <ReportInBox width="10.88vw" height="27.40vw">
+          {!started && (
+            <p
+              className={s.makeButton}
+              onClick={loading ? undefined : handleStart}
+              aria-busy={loading}
             >
-              {loading ? '생성 중...' : '다른질문 보기'}
-            </button>
+              {loading ? <LoadingSpinner /> : "생성하기"}
+            </p>
           )}
 
-          <ReportInBox width="10.88vw" height="27.40vw">
-            {!started && (
-              <p
-                className={s.makeButton}
-                onClick={loading ? undefined : handleStart}
-                aria-busy={loading}
-              >
-                {loading ? <LoadingSpinner /> : '생성하기'}
-              </p>
-            )}
+          {started && (
+            <div className={s.qaFourBox}>
+              {qa.slice(0, 4).map((q, i) => (
+                <React.Fragment key={i}>
+                  <div className={s.qaItem}>
+                    <span>Q. {q.question}</span>
+                    <p>A. {q.answer}</p>
+                  </div>
+                  {i < 3 && <div>...</div>}
+                </React.Fragment>
+              ))}
+            </div>
+          )}
+        </ReportInBox>
+      </ReportOutBox>
+    </div>
+  );
+};
 
-            {started && (
-              <div className={s.qaFourBox}>
-                {qaList.slice(0, 4).map((q, i) => (
-                  <React.Fragment key={i}>
-                    <div className={s.qaItem}>
-                      <span>Q. {q.question}</span>
-                      <p>A. {q.answer}</p>
-                    </div>
-                    {i < 3 && <div>...</div>}
-                  </React.Fragment>
-                ))}
-              </div>
-            )}
-          </ReportInBox>
-        </ReportOutBox>
-      </div>
-    );
-  }
-);
-
-QuestionsBox.displayName = 'QuestionsBox';
 export default QuestionsBox;

--- a/src/pages/mainPage/MainPage.tsx
+++ b/src/pages/mainPage/MainPage.tsx
@@ -19,11 +19,13 @@ import CHAR from "../../assets/images/character-2d.svg";
 import LINE1 from "../../assets/images/main/line1.svg";
 import LINE2 from "../../assets/images/main/line2.svg";
 import FadeUp from "./componenets/FadeUp";
+import { reportSession } from "../../utils/sessionStorage";
 
 const MainPage = () => {
   const navigate = useNavigate();
 
   const handleNavigate = (path: string) => {
+    reportSession.save(54);
     navigate(path);
   };
 

--- a/src/store/documentStore.ts
+++ b/src/store/documentStore.ts
@@ -1,0 +1,43 @@
+import { create } from "zustand";
+import { ItemState } from "../types/document";
+
+type Store = {
+  items: Record<number, ItemState>;
+  initItem: (id: number, title: string) => void;
+  updateItem: (id: number, patch: Partial<ItemState>) => void;
+  getAll: () => ItemState[]; // 전체 아이템 (id 포함)
+};
+
+// 초기값
+const makeDefault = (id: number, title = ""): ItemState => ({
+  id,
+  title,
+  userAnswer: "",
+  aiAnswer: "",
+  qa: [],
+});
+
+export const useDocStore = create<Store>((set, get) => ({
+  items: {},
+
+  initItem: (id, title) =>
+    set((s) => {
+      if (s.items[id]) return s;
+      return { items: { ...s.items, [id]: makeDefault(id, title) } };
+    }),
+
+  updateItem: (id, patch) =>
+    set((s) => {
+      const prev = s.items[id] ?? makeDefault(id);
+      const next: ItemState = { ...prev, ...patch, id };
+      return { items: { ...s.items, [id]: next } };
+    }),
+
+  getAll: () => {
+    const items = get().items;
+    return Object.keys(items)
+      .map((k) => items[Number(k)])
+      .filter((x): x is ItemState => Boolean(x))
+      .sort((a, b) => a.id - b.id);
+  },
+}));

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -1,53 +1,40 @@
 /* ===== 공통 타입 ===== */
 
-// 단일 Q&A 아이템 (QuestionsBox, ItemSnapshot 등에서 사용)
+// 단일 Q&A 아이템
 export type QAItem = { question: string; answer: string };
 
-// 첨삭 제목/설명 (RevisingBox props, DocumentItemProps 기본값)
+// 첨삭 제목/설명
 export type RevisingTitle = {
   title: string;
   explanation: string;
 };
 
-// RevisingBox 핸들 (사용자/AI 답변 getter)
-export type RevisingBoxHandle = {
-  getUserAnswer: () => string;
-  getAiAnswer: () => string;
-  getAnswerId: () => number | null;
-};
+/* ===== Zustand용 상태 ===== */
 
-// QuestionsBox 핸들 (현재 노출되는 QA getter)
-export type QuestionsBoxHandle = {
-  getVisibleQA: () => QAItem[];
-};
-
-/* ===== DocumentItem 전용 ===== */
-
-// DocumentItem 스냅샷 구조 (title, 답변, QA 포함)
-export type ItemSnapshot = {
+export type ItemState = {
+  id: number; // questionNumber
   title: string;
   userAnswer: string;
   aiAnswer: string;
   qa: QAItem[];
 };
 
-// DocumentItem 핸들 (getSnapshot 제공)
-export type ItemHandle = {
-  getSnapshot: () => ItemSnapshot;
-};
+/* ===== 컴포넌트 Props ===== */
 
-// DocumentItem props (RevisingTitle + PDF 내보내기 콜백)
+// DocumentItem
 export type DocumentItemProps = RevisingTitle & {
+  questionNumber: number;
   onExportAll?: () => void;
   onRequireWarn?: () => void;
 };
 
-export type ExtraProps = {
-  getAiAnswer?: () => string;
-  getAnswerId?: () => number | null;
-  onRequireWarn?: () => void;
+// QuestionsBox
+export type QuestionsBoxProps = {
   questionNumber: number;
+  onRequireWarn?: () => void;
 };
+
+/* ===== API 타입 ===== */
 
 export type CreateAiAnswerRequest = {
   questionNumber: number;


### PR DESCRIPTION
## 📝 작업 내용
<!-- 작업한 내용을 모두 작성해 주세요. -->
- pdf 관련 상태 zustand로 관리
    - DocumentItem 하위의 사용자 입력/AI 답변/QA를 documentStore(Zustand)로 관리하도록 변경
    - ref / useImperativeHandle 제거, 합본 PDF 수집 경로를 store로 일원화
- 변경된 동작
전:  각 DocumentItem에서 ref로 스냅샷 수집 → DocumentPage에서 전부 모아 MyDocumentAll에 전달
후: 모든 데이터는 store에 → DocumentPage에서 getAll()만 호출해 MyDocumentAll에 전달 (ref 의존성 제거)

## #️⃣ 연관 이슈
<!-- 연관된 이슈를 태그해 주세요. -->
close #80 

## 👀 스크린샷
<!-- 결과 이미지를 첨부해 주세요. -->
